### PR TITLE
Fix build breaking due to unpinned poetry

### DIFF
--- a/.github/workflows/controller_unittests.yml
+++ b/.github/workflows/controller_unittests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./oidc-controller
         run: |
-          pip3 install --no-cache-dir poetry
+          pip3 install --no-cache-dir poetry==1.8.3
           poetry install
       - name: Lint with black
         working-directory: ./oidc-controller

--- a/docker/oidc-controller/Dockerfile
+++ b/docker/oidc-controller/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12 AS main
 WORKDIR /app
 
 ENV POETRY_VIRTUALENVS_CREATE=false
-RUN pip3 install --no-cache-dir poetry
+RUN pip3 install --no-cache-dir poetry==1.8.3
 
 COPY pyproject.toml poetry.lock README.md ./
 RUN poetry install --only main


### PR DESCRIPTION
Poetry released a major version 2.0. We weren't pinning Poetry in the dockerfile so it just gets the latest one and that now errors with:

```
4.878 Installing the current project: acapy-vc-authn-oidc (0.2.2)
4.880
4.880 Warning: The current project could not be installed: No file/folder found for package acapy-vc-authn-oidc
4.880 If you do not want to install the current project use --no-root.
4.880 If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
4.880 If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.
4.880
------
Dockerfile:9
--------------------
   7 |
   8 |     COPY pyproject.toml poetry.lock README.md ./
   9 | >>> RUN poetry install --only main
  10 |
  11 |     COPY ./oidc-controller .
--------------------
ERROR: failed to solve: process "/bin/sh -c poetry install --only main" did not complete successfully: exit code: 1
```

Specify Poetry version to fix this.

Will look at fix and any other enhancements for new Poetry in 
https://github.com/openwallet-foundation/acapy-vc-authn-oidc/issues/701