### PR TITLE
ACA-Py 1.2.2 update

### DIFF
--- a/charts/vc-authn-oidc/values.yaml
+++ b/charts/vc-authn-oidc/values.yaml
@@ -241,7 +241,7 @@ acapy:
     repository: ghcr.io/openwallet-foundation/acapy-agent
     pullPolicy: IfNotPresent
     pullSecrets: []
-    tag: py3.12-1.2.1
+    tag: py3.12-1.2.2
 
   ## ServiceAccount configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

--- a/demo/vue/app/frontend/package-lock.json
+++ b/demo/vue/app/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/eslint-parser": "^7.26.5",
+        "@babel/eslint-parser": "^7.26.8",
         "@vue/eslint-config-prettier": "^10.2.0",
         "axios": "^1.7.9",
         "core-js": "^3.40.0",
@@ -33,8 +33,8 @@
         "eslint-plugin-vue": "^9.32.0",
         "eslint-plugin-vuetify": "^1.1.0",
         "lodash": "^4.17.21",
-        "prettier": "^3.4.2",
-        "sass": "^1.83.4",
+        "prettier": "^3.5.0",
+        "sass": "^1.84.0",
         "sass-loader": "^14.2.1",
         "vue-cli-plugin-vuetify": "^2.5.8",
         "vue-template-compiler": "^2.7.16",
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz",
-      "integrity": "sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.8.tgz",
+      "integrity": "sha512-3tBctaHRW6xSub26z7n8uyOTwwUsCdvIug/oxBH9n6yCO5hMj2vwDJAo7RbBMKrM7P+W2j61zLKviJQFGOYKMg==",
       "license": "MIT",
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -13974,9 +13974,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.0.tgz",
+      "integrity": "sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -14590,9 +14590,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.83.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
-      "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
+      "version": "1.84.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.84.0.tgz",
+      "integrity": "sha512-XDAbhEPJRxi7H0SxrnOpiXFQoUJHwkR2u3Zc4el+fK/Tt5Hpzw5kkQ59qVDfvdaUq6gCrEZIbySFBM2T9DNKHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/demo/vue/app/frontend/package.json
+++ b/demo/vue/app/frontend/package.json
@@ -17,7 +17,7 @@
     "reinstall": "npm run purge && npm install"
   },
   "dependencies": {
-    "@babel/eslint-parser": "^7.26.5",
+    "@babel/eslint-parser": "^7.26.8",
     "@vue/eslint-config-prettier": "^10.2.0",
     "axios": "^1.7.9",
     "core-js": "^3.40.0",
@@ -41,8 +41,8 @@
     "eslint-plugin-vue": "^9.32.0",
     "eslint-plugin-vuetify": "^1.1.0",
     "lodash": "^4.17.21",
-    "prettier": "^3.4.2",
-    "sass": "^1.83.4",
+    "prettier": "^3.5.0",
+    "sass": "^1.84.0",
     "sass-loader": "^14.2.1",
     "vue-cli-plugin-vuetify": "^2.5.8",
     "vue-template-compiler": "^2.7.16",

--- a/demo/vue/app/package-lock.json
+++ b/demo/vue/app/package-lock.json
@@ -22,7 +22,7 @@
         "fs-extra": "^11.3.0",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^9.0.2",
-        "keycloak-connect": "^26.1.0",
+        "keycloak-connect": "^26.1.1",
         "winston": "^3.17.0",
         "winston-transport": "^4.9.0"
       },
@@ -7584,9 +7584,9 @@
       }
     },
     "node_modules/keycloak-connect": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.0.tgz",
-      "integrity": "sha512-z5JvmDkGtrCKeuofo1pMR82eHbAQ6GvpdFDGXUt8PETm+7YdVYX2oGRx7vp6tntZsJaHnWCMc7d0/zZuTEgDRg==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-26.1.1.tgz",
+      "integrity": "sha512-2wvNJXldB9Em+mp6liJ+AnftcJovFEvNhUgv3hblNDmVihBoBqn4zFlwLIN41lo0H8CicB2T86xZ5U2MiQ9FFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "jwk-to-pem": "^2.0.0"

--- a/demo/vue/app/package.json
+++ b/demo/vue/app/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "^11.3.0",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
-    "keycloak-connect": "^26.1.0",
+    "keycloak-connect": "^26.1.1",
     "winston": "^3.17.0",
     "winston-transport": "^4.9.0"
   },

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -102,7 +102,7 @@ services:
       - vc_auth
 
   aca-py:
-    image: ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.2.1
+    image: ghcr.io/openwallet-foundation/acapy-agent:py3.12-1.2.2
     environment:
       - ACAPY_LABEL=${AGENT_NAME}
       - ACAPY_ENDPOINT=${AGENT_ENDPOINT}


### PR DESCRIPTION
Update to ACA-Py 1.2.2. 
That includes an askar update from 0.3 to 0.4 so tested out locally on an existing VCAuth.