### PR TITLE
Use well known goal code for proof-request

### DIFF
--- a/demo/vue/app/frontend/package-lock.json
+++ b/demo/vue/app/frontend/package-lock.json
@@ -14796,10 +14796,11 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }

--- a/demo/vue/app/package-lock.json
+++ b/demo/vue/app/package-lock.json
@@ -2817,9 +2817,10 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
-      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/oidc-controller/api/core/acapy/out_of_band.py
+++ b/oidc-controller/api/core/acapy/out_of_band.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, ConfigDict, Field
+
 from .service_decorator import OOBServiceDecorator
 
 
@@ -17,7 +18,7 @@ class OutOfBandMessage(BaseModel):
         default="https://didcomm.org/out-of-band/1.1/invitation",
         alias="@type",
     )
-    goal_code: str = Field(default="request-proof")
+    goal_code: str = Field(default="aries.vc.verifier.once")
     label: str = Field(
         default="acapy-vc-authn Out-of-Band present-proof authorization request"
     )


### PR DESCRIPTION
Update goal code to use `aries.vc.verifier.once`, which indicates to the holder wallet the interaction is to be considered terminated after the first verification.