### PR TITLE
Tweaks to image publishing flow

### DIFF
--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -1,9 +1,13 @@
-name: Build, Update Config, and Deploy Development
+name: Build latest development image
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+    paths:
+      - "docker/oidc-controller/**"
+      - "oidc-controller/**"
+      - "html-templates/**"
 jobs:
   build:
     name: "Build ACAPy VC-AuthN"
@@ -12,5 +16,4 @@ jobs:
     with:
       tag: "dev"
       ref: "main"
-      platforms: "linux/amd64"
-
+      platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -14,6 +14,5 @@ jobs:
     if: github.repository_owner == 'openwallet-foundation'
     uses: ./.github/workflows/publish.yml
     with:
-      tag: "dev"
       ref: "main"
       platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -8,6 +8,8 @@ on:
       - "docker/oidc-controller/**"
       - "oidc-controller/**"
       - "html-templates/**"
+      - "pyproject.toml"
+      - "poetry.lock"
 jobs:
   build:
     name: "Build ACAPy VC-AuthN"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value={{inputs.tag}}
+            type=raw,value=${{ inputs.tag }}
 
       - name: Build and Push Image to ghcr.io
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,11 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=${{ inputs.tag }}
+            # set dev tag when building from the default branch (main)
+            type=raw,value=dev,enable={{is_default_branch}}
+            # set latest tag for published release
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            
 
       - name: Build and Push Image to ghcr.io
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
       platforms:
         description: "Platforms - Comma separated list of the platforms to support."
         required: true
-        default: linux/amd64
+        default: linux/amd64,linux/arm64
         type: string
       ref:
         description: "Optional - The branch, tag or SHA to checkout."
@@ -94,8 +94,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=ref,event=pr
-            type=sha
+            type=raw,value={{inputs.tag}}
 
       - name: Build and Push Image to ghcr.io
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,10 @@
 name: Publish ACAPy VC-AuthN Image
-run-name: Publish ACAPy VC-AuthN ${{ inputs.tag || github.event.release.tag_name }} Image
+run-name: Publish ACAPy VC-AuthN ${{ github.ref_name || github.event.release.tag_name }} Image
 on:
   release:
     types: [published]
   workflow_call:
     inputs:
-      tag:
-        description: "Image tag"
-        required: true
-        type: string
       platforms:
         description: "Platforms - Comma separated list of the platforms to support."
         required: true
@@ -28,14 +24,10 @@ on:
 
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Image tag"
-        required: true
-        type: string
       platforms:
         description: "Platforms - Comma separated list of the platforms to support."
         required: true
-        default: linux/amd64
+        default: linux/amd64,linux/arm64
         type: string
       ref:
         description: "Optional - The branch, tag or SHA to checkout."


### PR DESCRIPTION
This PR adds some tweaks to the build steps for the vc-authn image. In particular:
- Scopes development builds to only happen when relevant changes are pushed to `main` by specifying context directories
- Adds `linux/arm64` as a default target platform
- Adds conditional tagging of the images: images will be tagged as `dev` if the build originates from the main branch and will include the `latest` tag if the build is triggered by a release

c.c.: @i5okie 