### PR TITLE
Use BC showcase person credential for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,20 @@ curl -X 'POST' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
-  "ver_config_id": "test-proof",
+  "ver_config_id": "showcase-person",
   "subject_identifier": "",
   "generate_consistent_identifier": true,
   "proof_request": {
-    "name": "Test Proof-Request",
+    "name": "BC Wallet Showcase Person",
     "version": "1.0",
     "requested_attributes": [
 
       {
-        "names": ["attr1", "attr2", "attr3"],
+        "names": ["given_names", "family_name", "country"],
         "restrictions": [
           {
-              "schema_name": "test-schema"
+            "schema_name": "Person",
+            "issuer_did": "QEquAHkM35w4XVT3Ku5yat"
           }
         ]
       }

--- a/demo/vue/app/frontend/src/store/modules/auth.js
+++ b/demo/vue/app/frontend/src/store/modules/auth.js
@@ -19,7 +19,7 @@ export default {
     // In most cases, when this becomes populated, we end up doing a redirect flow,
     // so when we return to the app, it is fresh again and undefined
     redirectUri: undefined,
-    presReqConfId: 'test-proof', //TODO: load this via config response
+    presReqConfId: 'showcase-person', //TODO: load this via config response
   },
   getters: {
     authenticated: () => Vue.prototype.$keycloak.authenticated,

--- a/oidc-controller/api/core/oidc/tests/__mocks__.py
+++ b/oidc-controller/api/core/oidc/tests/__mocks__.py
@@ -1,11 +1,8 @@
 from datetime import datetime, timedelta
 
-from api.verificationConfigs.models import (
-    VerificationConfig,
-    VerificationProofRequest,
-    MetaData,
-)
 from api.authSessions.models import AuthSession
+from api.verificationConfigs.models import (MetaData, VerificationConfig,
+                                            VerificationProofRequest)
 
 # Presentation returned from the debug webhook
 presentation = {
@@ -1326,7 +1323,7 @@ presentation = {
 auth_session = AuthSession(
     pres_exch_id="e444bc3e-346d-47d1-882d-39c014b8978c",
     expired_timestamp=datetime.now() + timedelta(seconds=3000),
-    ver_config_id="test-proof",
+    ver_config_id="showcase-person",
     request_parameters={
         "scope": "openid vc_authn",
         "state": "oFLNfUyzDtWHmc61dNiQZkVZRsRUUXZ5KZIiQBeQuJQ.xfaKQBh1xfQ.T02DEr3QRTmMUfjegc9fQQ",

--- a/oidc-controller/api/core/oidc/tests/__mocks__.py
+++ b/oidc-controller/api/core/oidc/tests/__mocks__.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timedelta
 
 from api.authSessions.models import AuthSession
-from api.verificationConfigs.models import (MetaData, VerificationConfig,
-                                            VerificationProofRequest)
+from api.verificationConfigs.models import (
+    MetaData,
+    VerificationConfig,
+    VerificationProofRequest,
+)
 
 # Presentation returned from the debug webhook
 presentation = {


### PR DESCRIPTION
Restores the showcase person credential to be used in the local demo, providing easy access to a credential.