### PR TITLE
Implement socket ID management in AuthSession for High Availability

### DIFF
--- a/oidc-controller/api/authSessions/crud.py
+++ b/oidc-controller/api/authSessions/crud.py
@@ -89,3 +89,12 @@ class AuthSessionCRUD:
             )
 
         return AuthSession(**auth_sess)
+
+    async def get_by_socket_id(self, socket_id: str) -> AuthSession | None:
+        col = self._db.get_collection(COLLECTION_NAMES.AUTH_SESSION)
+        auth_sess = col.find_one({"socket_id": socket_id})
+
+        if auth_sess is None:
+            return None
+
+        return AuthSession(**auth_sess)

--- a/oidc-controller/api/authSessions/models.py
+++ b/oidc-controller/api/authSessions/models.py
@@ -27,6 +27,7 @@ class AuthSessionBase(BaseModel):
     pyop_auth_code: str
     response_url: str
     presentation_request_msg: dict | None = None
+    socket_id: str | None = None
     model_config = ConfigDict(populate_by_name=True)
     created_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/oidc-controller/api/routers/acapy_handler.py
+++ b/oidc-controller/api/routers/acapy_handler.py
@@ -11,7 +11,7 @@ from ..authSessions.models import AuthSession, AuthSessionPatch, AuthSessionStat
 from ..db.session import get_db
 
 from ..core.config import settings
-from ..routers.socketio import sio, connections_reload
+from ..routers.socketio import sio, get_socket_id_for_pid
 
 logger: structlog.typing.FilteringBoundLogger = structlog.getLogger(__name__)
 
@@ -39,8 +39,7 @@ async def post_topic(request: Request, topic: str, db: Database = Depends(get_db
 
             # Get the saved websocket session
             pid = str(auth_session.id)
-            connections = connections_reload()
-            sid = connections.get(pid)
+            sid = await get_socket_id_for_pid(pid, db)
             logger.debug(f"sid: {sid} found for pid: {pid}")
 
             if webhook_body["state"] == "presentation-received":

--- a/oidc-controller/api/routers/oidc.py
+++ b/oidc-controller/api/routers/oidc.py
@@ -31,7 +31,7 @@ from ..core.oidc.issue_token_service import Token
 from ..db.session import get_db
 
 # Access to the websocket
-from ..routers.socketio import connections_reload, sio
+from ..routers.socketio import get_socket_id_for_pid, sio
 
 from ..verificationConfigs.crud import VerificationConfigCRUD
 from ..verificationConfigs.helpers import VariableSubstitutionError
@@ -58,8 +58,7 @@ async def poll_pres_exch_complete(pid: str, db: Database = Depends(get_db)):
     auth_session = await AuthSessionCRUD(db).get(pid)
 
     pid = str(auth_session.id)
-    connections = connections_reload()
-    sid = connections.get(pid)
+    sid = await get_socket_id_for_pid(pid, db)
 
     """
      Check if proof is expired. But only if the proof has not been started.

--- a/oidc-controller/api/routers/presentation_request.py
+++ b/oidc-controller/api/routers/presentation_request.py
@@ -9,7 +9,7 @@ from ..authSessions.crud import AuthSessionCRUD
 from ..authSessions.models import AuthSession, AuthSessionState
 
 from ..core.config import settings
-from ..routers.socketio import sio, connections_reload
+from ..routers.socketio import sio, get_socket_id_for_pid
 from ..routers.oidc import gen_deep_link
 from ..db.session import get_db
 
@@ -22,8 +22,7 @@ async def toggle_pending(db, auth_session: AuthSession):
     # We need to set this to pending now
     auth_session.proof_status = AuthSessionState.PENDING
     await AuthSessionCRUD(db).patch(auth_session.id, auth_session)
-    connections = connections_reload()
-    sid = connections.get(str(auth_session.id))
+    sid = await get_socket_id_for_pid(str(auth_session.id), db)
     if sid:
         await sio.emit("status", {"status": "pending"}, to=sid)
 
@@ -64,8 +63,7 @@ async def send_connectionless_proof_req(
     )
 
     # Get the websocket session
-    connections = connections_reload()
-    sid = connections.get(str(auth_session.id))
+    sid = await get_socket_id_for_pid(str(auth_session.id), db)
 
     # If the qrcode has been scanned, toggle the pending flag
     if auth_session.proof_status is AuthSessionState.NOT_STARTED:

--- a/oidc-controller/api/routers/socketio.py
+++ b/oidc-controller/api/routers/socketio.py
@@ -1,10 +1,13 @@
 import socketio  # For using websockets
 import logging
+from fastapi import Depends
+from pymongo.database import Database
+
+from ..authSessions.crud import AuthSessionCRUD
+from ..authSessions.models import AuthSessionPatch
+from ..db.session import get_db
 
 logger = logging.getLogger(__name__)
-
-
-connections = {}
 
 sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
 
@@ -18,20 +21,43 @@ async def connect(sid, socket):
 
 @sio.event
 async def initialize(sid, data):
-    global connections
-    # Store websocket session matched to the presentation exchange id
-    connections[data.get("pid")] = sid
+    # Store websocket session ID in the AuthSession
+    db = await get_db()
+    pid = data.get("pid")
+    if pid:
+        try:
+            auth_session = await AuthSessionCRUD(db).get(pid)
+            patch_data = auth_session.model_dump()
+            patch_data['socket_id'] = sid
+            patch = AuthSessionPatch(**patch_data)
+            await AuthSessionCRUD(db).patch(pid, patch)
+            logger.debug(f"Stored socket_id {sid} for pid {pid}")
+        except Exception as e:
+            logger.error(f"Failed to store socket_id for pid {pid}: {e}")
 
 
 @sio.event
 async def disconnect(sid):
-    global connections
     logger.info(f">>> disconnect : sid={sid}")
-    # Remove websocket session from the store
-    if len(connections) > 0:
-        connections = {k: v for k, v in connections.items() if v != sid}
+    # Clear socket_id from AuthSession
+    db = await get_db()
+    try:
+        auth_session = await AuthSessionCRUD(db).get_by_socket_id(sid)
+        if auth_session:
+            patch_data = auth_session.model_dump()
+            patch_data['socket_id'] = None
+            patch = AuthSessionPatch(**patch_data)
+            await AuthSessionCRUD(db).patch(str(auth_session.id), patch)
+            logger.debug(f"Cleared socket_id {sid} for pid {auth_session.id}")
+    except Exception as e:
+        logger.error(f"Failed to clear socket_id {sid}: {e}")
 
 
-def connections_reload():
-    global connections
-    return connections
+async def get_socket_id_for_pid(pid: str, db: Database) -> str | None:
+    """Get current socket ID for presentation ID"""
+    try:
+        auth_session = await AuthSessionCRUD(db).get(pid)
+        return auth_session.socket_id
+    except Exception as e:
+        logger.error(f"Failed to get socket_id for pid {pid}: {e}")
+        return None


### PR DESCRIPTION
This PR resolves #812 by replacing the in memory websocket connection managment with a MongoDB based solution. 

To do this I added websocket_id to the AuthSession and utilize it as follows:

- Introduced `get_by_socket_id` method in `AuthSessionCRUD` for retrieval by socket ID.
- Modified `initialize` event in `socketio` to store the socket ID in the corresponding `AuthSession`.
- Updated `disconnect` event to clear the socket ID from the `AuthSession` when a client disconnects.
- Replaced direct connections management with asynchronous methods to obtain socket IDs for presentation IDs in relevant router functions.