### PR TITLE
Make all created and expired timestamps rather than strings

### DIFF
--- a/oidc-controller/api/authSessions/crud.py
+++ b/oidc-controller/api/authSessions/crud.py
@@ -5,7 +5,6 @@ from pymongo.database import Database
 from pymongo.errors import DuplicateKeyError
 from fastapi import HTTPException
 from fastapi import status as http_status
-from fastapi.encoders import jsonable_encoder
 
 from ..core.models import PyObjectId
 from .models import (
@@ -25,7 +24,7 @@ class AuthSessionCRUD:
 
     async def create(self, auth_session: AuthSessionCreate) -> AuthSession:
         col = self._db.get_collection(COLLECTION_NAMES.AUTH_SESSION)
-        result = col.insert_one(jsonable_encoder(auth_session))
+        result = col.insert_one(auth_session.model_dump())
         return AuthSession(**col.find_one({"_id": result.inserted_id}))
 
     async def get_by_connection_id(self, connection_id: str) -> AuthSession | None:


### PR DESCRIPTION
This PR resolves #824 by inserting auth_sessions using a model dump
rather than JSON encoding them. This prevents dates being encoded as a
string rather than a timestamp.